### PR TITLE
Fixing deps and changing gulp-svgo to gulpsvgmin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ var autoprefixer = require('gulp-autoprefixer');
 var iconfont = require('gulp-iconfont');
 var consolidate = require('gulp-consolidate');
 var svgspritesheet = require('gulp-svg-spritesheet');
-var svgo = require('gulp-svgo');
+var svgmin = require('gulp-svgmin');
 var svg2png = require('gulp-svg2png');
 var imagemin = require('gulp-imagemin');
 var jscsConfig = require('./package').jscs;
@@ -52,7 +52,7 @@ gulp.task('iconfont', function () {
 gulp.task('svgSprite', function () {
     return gulp.src('assets/img/sprites/*')
         .pipe(plumber())
-        .pipe(svgo())
+        .pipe(svgmin())
         .pipe(svgspritesheet({
             padding: 5,
             positioning: 'packed',

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   },
   "dependencies": {
     "browserify": "^9.0.3",
+    "jshint-stylish": "^1.0.0",
+    "lodash": "^3.3.0",
+    "through2": "^0.6.5"
+  },
+  "devDependencies": {
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-base64-inline": "^1.0.0",
@@ -20,11 +25,8 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-svg-spritesheet": "0.0.3",
     "gulp-svg2png": "^0.3.0",
-    "gulp-svgo": "^0.1.1",
     "gulp-uglify": "^1.1.0",
-    "jshint-stylish": "^1.0.0",
-    "lodash": "^3.3.0",
-    "through2": "^0.6.5"
+    "gulp-svgmin": "^1.2.0"
   },
   "jshintConfig": {
     "bitwise": false,


### PR DESCRIPTION
Changing gulp-svgo with gulp-svgmin. gulp-svgmin is official svgo gulp task.

Also moving all gulp stuff to dev deps.
